### PR TITLE
Fix render capture and add PLY pre-loading

### DIFF
--- a/web/js/gaussian_preview_v2.js
+++ b/web/js/gaussian_preview_v2.js
@@ -269,6 +269,52 @@ app.registerExtension({
                         const requestId = message.request_id;
                         const resolution = message.output_resolution || 2048;
                         const aspectRatio = message.output_aspect_ratio || "source";
+                        const plyFile = message.ply_file;
+                        const msgFilename = message.filename;
+
+                        // Pre-load PLY if not already loaded in the viewer
+                        if (plyFile && this.currentPlyFile !== plyFile) {
+                            try {
+                                const targetPath = `/view?filename=${encodeURIComponent(plyFile)}&type=output&subfolder=`;
+                                console.log("[GeomPack Gaussian v2] Pre-loading PLY for render:", targetPath);
+                                const response = await fetch(targetPath);
+                                if (response.ok) {
+                                    const arrayBuffer = await response.arrayBuffer();
+                                    iframe.contentWindow.postMessage({
+                                        type: "LOAD_MESH_DATA",
+                                        data: arrayBuffer,
+                                        filename: plyFile,
+                                        extrinsics: message.extrinsics || null,
+                                        intrinsics: message.intrinsics || null,
+                                        timestamp: Date.now()
+                                    }, "*", [arrayBuffer]);
+
+                                    this.currentPlyFile = plyFile;
+                                    this.currentFilename = msgFilename || plyFile;
+                                    if (window.GEOMPACK_PREVIEW_IFRAMES) {
+                                        window.GEOMPACK_PREVIEW_IFRAMES[this.currentPlyFile] = iframe;
+                                        window.GEOMPACK_PREVIEW_IFRAMES[this.currentFilename] = iframe;
+                                    }
+
+                                    // Give the viewer time to load and render the PLY
+                                    await new Promise(r => setTimeout(r, 3000));
+                                } else {
+                                    console.error("[GeomPack Gaussian v2] Failed to fetch PLY:", response.status);
+                                }
+                            } catch (err) {
+                                console.error("[GeomPack Gaussian v2] Failed to pre-load PLY:", err);
+                            }
+                        }
+
+                        // Apply camera state if provided
+                        if (message.camera_state && iframe.contentWindow) {
+                            iframe.contentWindow.postMessage({
+                                type: "APPLY_CAMERA_STATE",
+                                camera_state: message.camera_state
+                            }, "*");
+                            // Small delay for camera to settle
+                            await new Promise(r => setTimeout(r, 200));
+                        }
 
                         iframe.contentWindow.postMessage({
                             type: "OUTPUT_SETTINGS",

--- a/web/viewer_gaussian_v2.html
+++ b/web/viewer_gaussian_v2.html
@@ -387,10 +387,22 @@
             try {
                 console.log('[GaussianViewer] Creating scene...');
                 scene = new SPLAT.Scene();
-                
+
                 console.log('[GaussianViewer] Creating camera...');
                 camera = new SPLAT.Camera();
-                
+
+                // Patch canvas.getContext to force preserveDrawingBuffer: true
+                // This is required so that toDataURL() can read the rendered frame
+                // instead of getting a blank/black buffer after the browser composites.
+                const originalGetContext = canvas.getContext.bind(canvas);
+                canvas.getContext = function(type, attrs) {
+                    if (type === 'webgl2' || type === 'webgl') {
+                        attrs = Object.assign({}, attrs || {}, { preserveDrawingBuffer: true });
+                        console.log('[GaussianViewer] Patched getContext with preserveDrawingBuffer: true');
+                    }
+                    return originalGetContext(type, attrs);
+                };
+
                 console.log('[GaussianViewer] Creating renderer...');
                 renderer = new SPLAT.WebGLRenderer(canvas);
                 
@@ -1082,15 +1094,31 @@
         }
 
         async function renderForRequest(requestId, resolution, aspectRatio) {
+            // Wait for renderer and scene to be ready (up to 20 seconds)
+            const maxWait = 20000;
+            const interval = 250;
+            let waited = 0;
+            while ((!renderer || !renderer.canvas || !currentSplat) && waited < maxWait) {
+                await new Promise(r => setTimeout(r, interval));
+                waited += interval;
+            }
+
             if (!renderer || !renderer.canvas) {
+                console.error('[GaussianViewer] Render failed: renderer not ready after', waited, 'ms');
                 window.parent.postMessage({
                     type: 'RENDER_ERROR',
                     request_id: requestId,
-                    error: 'renderer not ready',
+                    error: 'renderer not ready after waiting ' + waited + 'ms',
                     source: 'preview_gaussian_v2',
                     timestamp: Date.now()
                 }, '*');
                 return;
+            }
+
+            if (!currentSplat) {
+                console.warn('[GaussianViewer] Render proceeding without splat after', waited, 'ms wait');
+            } else if (waited > 0) {
+                console.log('[GaussianViewer] Renderer and scene ready after', waited, 'ms');
             }
 
             try {
@@ -1100,6 +1128,9 @@
 
                 if (scene && camera) {
                     controls.update();
+                    renderer.render(scene, camera);
+                    // Allow an extra frame for the render to complete
+                    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
                     renderer.render(scene, camera);
                 }
 


### PR DESCRIPTION
## Summary
- **Fix blank render captures**: Patch `canvas.getContext` to force `preserveDrawingBuffer: true`, preventing blank/black frames when capturing via `toDataURL()` after the browser composites
- **Pre-load PLY before render**: When a render request arrives and the PLY isn't loaded yet, fetch and load it first, avoiding renders against an empty scene
- **Camera state support**: Apply camera state from render requests before capturing
- **Render readiness wait**: Wait up to 20s for renderer and scene to be ready before attempting render, with informative logging
- **Double-render frame sync**: Use `requestAnimationFrame` to ensure the frame is fully rendered before capture

## Test plan
- [ ] Load a `.ply` file in the Gaussian viewer and trigger a render capture — verify the output image is not blank
- [ ] Trigger a render request before the PLY is loaded — verify it pre-loads and renders correctly
- [ ] Verify camera state is applied when provided in render requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)